### PR TITLE
Remove the __typename from GQL queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- GraphQL queries will no longer show "__typename" in the request bodies ([Issue 20](https://github.com/rubrikinc/api-capture-chrome-extension/issues/20))
+
 ## v1.0.0
 
 - Small UI improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- GraphQL queries will no longer show "__typename" in the request bodies ([Issue 20](https://github.com/rubrikinc/api-capture-chrome-extension/issues/20))
+- GraphQL queries will no longer show the "__typename" field in the request and response bodies ([Issue 20](https://github.com/rubrikinc/api-capture-chrome-extension/issues/20))
 
 ## v1.0.0
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -167,9 +167,14 @@ export default class App extends React.Component {
               ? (httpMethod = "mutation")
               : (httpMethod = "query");
           }
-          // Convert the request data to a GraphQL AST document for easier
-          // processing
-          let ast = parse(JSON.parse(request.request.postData.text)["query"]);
+          // Remove any instances of "__typename" and then convert the request
+          // data to a GraphQL AST document for easier processing
+          let ast = parse(
+            JSON.parse(request.request.postData.text)["query"].replace(
+              /__typename/g,
+              ""
+            )
+          );
           try {
             path = ast["definitions"][0]["name"]["value"];
           } catch (error) {}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -53,6 +53,9 @@ const combinedBackgroundApiCalls = [
   ...polarisBackgroundApiCalls,
 ];
 
+// Create a blank string used to remove __type from the GQL response body
+let processedGQLResponse = "";
+
 export default class App extends React.Component {
   constructor(props) {
     super(props);
@@ -203,7 +206,41 @@ export default class App extends React.Component {
       // and is not in the shouldBeFilterd list
       if (isRubrikApiCall && !this.shouldBeFilterd(path)) {
         try {
-          request.getContent((content, encoding) => {
+          request.getContent((content) => {
+            // If present, remove "__typename from the response body"
+            if (content.includes("__typename")) {
+              // Split the string on each instance of "__typename" (i.e the key) and
+              // then remove the value for the typename
+              content.split(`"__typename":"`).forEach((item) => {
+                // Add the first line in the array
+                if (item.charAt(0) === "{") {
+                  processedGQLResponse += item;
+                } else {
+                  // Example line we are processing:
+                  //    Cluster","criticalSeverity":{
+                  //
+                  // where Cluster = the typename key that needs to be removed
+                  //
+                  // Find all occurances of "," in the string
+                  // splitIndex gives us the first instance of "," which
+                  // tells where we need to split the string to remove the
+                  // typename key
+                  let splitIndex = item.indexOf(",");
+                  // Create a new array that has the typename key as the first
+                  // value
+                  let typenameKey = [
+                    item.slice(0, splitIndex),
+                    item.slice(splitIndex + 1),
+                  ];
+                  // Remove the typenameKey from the array
+                  typenameKey.shift();
+                  processedGQLResponse += typenameKey;
+                }
+              });
+              content = processedGQLResponse;
+              processedGQLResponse = "";
+            }
+
             this.setState({
               apiCalls: [
                 ...this.state.apiCalls,


### PR DESCRIPTION
# Description

GraphQL queries will no longer show the "__typename" field in the request and response bodies

## Related Issue

- https://github.com/rubrikinc/api-capture-chrome-extension/issues/20

## Motivation and Context

The `typename` field is almost never relevant to automation and only clutters up the request and response bodies.

## How Has This Been Tested?

* Manual integration test in Gaia


## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)